### PR TITLE
RH-2 : 기본적인 페이지 구조 및 routing 설정 추가

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@types/react-dom": "^18.3.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
+        "react-router-dom": "^6.26.1",
         "react-scripts": "5.0.1",
         "typescript": "^4.9.5",
         "web-vitals": "^2.1.4"
@@ -3292,6 +3293,14 @@
         "webpack-plugin-serve": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@remix-run/router": {
+      "version": "1.19.1",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.19.1.tgz",
+      "integrity": "sha512-S45oynt/WH19bHbIXjtli6QmwNYvaz+vtnubvNpNDvUOoA/OWh6j1OikIP3G+v5GHdxyC6EXoChG3HgYGEUfcg==",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@rollup/plugin-babel": {
@@ -15176,6 +15185,36 @@
       "integrity": "sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A==",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-router": {
+      "version": "6.26.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.26.1.tgz",
+      "integrity": "sha512-kIwJveZNwp7teQRI5QmwWo39A5bXRyqpH0COKKmPnyD2vBvDwgFXSqDUYtt1h+FEyfnE8eXr7oe0MxRzVwCcvQ==",
+      "dependencies": {
+        "@remix-run/router": "1.19.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "6.26.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.26.1.tgz",
+      "integrity": "sha512-veut7m41S1fLql4pLhxeSW3jlqs+4MtjRLj0xvuCEXsxusJCbs6I8yn9BxzzDX2XDgafrccY6hwjmd/bL54tFw==",
+      "dependencies": {
+        "@remix-run/router": "1.19.1",
+        "react-router": "6.26.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "node_modules/react-scripts": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@types/react-dom": "^18.3.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "react-router-dom": "^6.26.1",
     "react-scripts": "5.0.1",
     "typescript": "^4.9.5",
     "web-vitals": "^2.1.4"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,12 +1,24 @@
 import React from 'react';
+import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
 import './App.css';
+import HomePage from './pages/page';
+import CustomerSupportPage from './pages/customer_support/page';
+import OurStoryPage from './pages/our_story/page';
+import MainServicePage from './pages/main_service/page';
+import ReHubTemplatesPage from './pages/re_hub_templates/page';
 
-function App() {
+const App: React.FC = () => {
   return (
-    <div className="App">
-      <div>회고서비스 시작</div>
-    </div>
+    <Router>
+      <Routes>
+        <Route path="/" element={<HomePage />} />
+        <Route path="/main-service" element={<MainServicePage />} />
+        <Route path="/rehub-templates" element={<ReHubTemplatesPage />} />
+        <Route path="/our-story" element={<OurStoryPage />} />
+        <Route path="/customer-support" element={<CustomerSupportPage />} />
+      </Routes>
+    </Router>
   );
-}
+};
 
 export default App;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,24 +1,19 @@
 import React from 'react';
-import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
+import { BrowserRouter as Router, useRoutes } from 'react-router-dom';
 import './App.css';
-import HomePage from './pages/page';
-import CustomerSupportPage from './pages/customer_support/page';
-import OurStoryPage from './pages/our_story/page';
-import MainServicePage from './pages/main_service/page';
-import ReHubTemplatesPage from './pages/re_hub_templates/page';
+import routes from './routes';
 
 const App: React.FC = () => {
+  return useRoutes(routes);
+};
+
+// App에서는 Router를 사용할 수가 없어서 wrapper 객체를 만들어서 사용
+const AppWrapper: React.FC = () => {
   return (
     <Router>
-      <Routes>
-        <Route path="/" element={<HomePage />} />
-        <Route path="/main-service" element={<MainServicePage />} />
-        <Route path="/rehub-templates" element={<ReHubTemplatesPage />} />
-        <Route path="/our-story" element={<OurStoryPage />} />
-        <Route path="/customer-support" element={<CustomerSupportPage />} />
-      </Routes>
+      <App />
     </Router>
   );
 };
 
-export default App;
+export default AppWrapper;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,13 +1,13 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
-import App from './App';
+import AppWrapper from './App';
 
 const root = ReactDOM.createRoot(
   document.getElementById('root') as HTMLElement
 );
 root.render(
   <React.StrictMode>
-    <App />
+    <AppWrapper />
   </React.StrictMode>
 );

--- a/src/pages/customer_support/page.tsx
+++ b/src/pages/customer_support/page.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+const CustomerSupportPage = () => {
+  return (
+    <h1>Here is CustomerSupportPage</h1>
+  );
+};
+
+export default CustomerSupportPage;

--- a/src/pages/main_service/page.tsx
+++ b/src/pages/main_service/page.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+const MainServicePage = () => {
+  return (
+    <h1>Here is MainServicePage</h1>
+  );
+};
+
+export default MainServicePage;

--- a/src/pages/our_story/page.tsx
+++ b/src/pages/our_story/page.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+const OurStoryPage = () => {
+  return (
+    <h1>Here is OurStoryPage</h1>
+  );
+};
+
+export default OurStoryPage;

--- a/src/pages/page.tsx
+++ b/src/pages/page.tsx
@@ -10,7 +10,7 @@ const HomePage = () => {
       <ul>
         <li><Link to={"/"}>ReHub</Link></li>
         <li><Link to={"/main-service"}>주요 서비스</Link></li>
-        <li><Link to={"/reHub-templates"}>템플릿</Link></li>
+        <li><Link to={"/re-hub-templates"}>템플릿</Link></li>
         <li><Link to={"/customer-support"}>고객지원</Link></li>
       </ul>
       <button>시작하기</button>

--- a/src/pages/page.tsx
+++ b/src/pages/page.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+
+const HomePage = () => {
+  return (
+    <div>
+      <h1>Rehub(Retrospect Hub)</h1>
+      <h2>당신이 원하는 회고 서비스</h2>
+      <h3>Route pages</h3>
+      <ul>
+        <li><Link to={"/"}>ReHub</Link></li>
+        <li><Link to={"/main-service"}>주요 서비스</Link></li>
+        <li><Link to={"/reHub-templates"}>템플릿</Link></li>
+        <li><Link to={"/customer-support"}>고객지원</Link></li>
+      </ul>
+      <button>시작하기</button>
+    </div>
+  );
+};
+
+export default HomePage;

--- a/src/pages/re_hub_templates/page.tsx
+++ b/src/pages/re_hub_templates/page.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+const ReHubTemplatesPage = () => {
+  return (
+    <h1>Here is ReHubTemplatesPage</h1>
+  );
+};
+
+export default ReHubTemplatesPage;

--- a/src/routes/CustomerSupportRoutes.tsx
+++ b/src/routes/CustomerSupportRoutes.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { RouteObject } from 'react-router-dom';
+import CustomerSupportPage from '../pages/customer_support/page';
+
+const customerSupportRoutes: RouteObject[] = [
+  {
+    path: '/customer-support',
+    element: <CustomerSupportPage />,
+  },
+];
+
+export default customerSupportRoutes;

--- a/src/routes/HomeRoutes.tsx
+++ b/src/routes/HomeRoutes.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { RouteObject } from 'react-router-dom';
+import HomePage from '../pages/page';
+
+const homeRoutes: RouteObject[] = [
+  {
+    path: '/',
+    element: <HomePage />,
+  },
+];
+
+export default homeRoutes;

--- a/src/routes/MainServiceRoutes.tsx
+++ b/src/routes/MainServiceRoutes.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { RouteObject } from 'react-router-dom';
+import MainServicePage from '../pages/main_service/page';
+
+const mainServiceRoutes: RouteObject[] = [
+  {
+    path: '/main-service',
+    element: <MainServicePage />,
+  },
+];
+
+export default mainServiceRoutes;

--- a/src/routes/OurStoryRoutes.tsx
+++ b/src/routes/OurStoryRoutes.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { RouteObject } from 'react-router-dom';
+import OurStoryPage from '../pages/our_story/page';
+
+const ourStoryRoutes: RouteObject[] = [
+  {
+    path: '/our-story',
+    element: <OurStoryPage />,
+  },
+];
+
+export default ourStoryRoutes;

--- a/src/routes/ReHubTemplatesRoutes.tsx
+++ b/src/routes/ReHubTemplatesRoutes.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { RouteObject } from 'react-router-dom';
+import ReHubTemplatesPage from '../pages/re_hub_templates/page';
+
+const reHubTemplateRoutes: RouteObject[] = [
+  {
+    path: '/re-hub-templates',
+    element: <ReHubTemplatesPage />,
+  },
+];
+
+export default reHubTemplateRoutes;

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,0 +1,16 @@
+import { RouteObject } from 'react-router-dom';
+import homeRoutes from './HomeRoutes';
+import mainServiceRoutes from './MainServiceRoutes';
+import reHubTemplateRoutes from './ReHubTemplatesRoutes';
+import ourStoryRoutes from './OurStoryRoutes';
+import customerSupportRoutes from './CustomerSupportRoutes';
+
+const routes: RouteObject[] = [
+  ...homeRoutes,
+  ...mainServiceRoutes,
+  ...reHubTemplateRoutes,
+  ...ourStoryRoutes,
+  ...customerSupportRoutes,
+];
+
+export default routes;


### PR DESCRIPTION
jira : https://choorai.atlassian.net/browse/RH-2
wiki : https://github.com/choorai/retrospect-frontend/wiki/RH%E2%80%902-:-welcome-%ED%8E%98%EC%9D%B4%EC%A7%80-%EA%B0%9C%EB%B0%9C

## 진행
현재 과제는 PR을 나눠서 진행할 예정입니다.
1. [현재 PR] 페이지 구조를 디렉토리로 구분하는 기준을 잡고, routing 설정을 하는 것
2. 메인 페이지(welcome page) markup 작업

## 구현 내용
- `react-router-dom` 의존성 추가 (최신버전)
- routing 모듈화
- 페이지 구조 정의
  - `pages` 하위에 각 페이지별로 directory를 만들고, 각 directory별 `page.tsx`가 index.html과 동일한 역할을 합니다. (각 dir별 root page 역할)


## 리뷰 포인트
- 페이지 추가할 때 어떻게 추가해야할지 알 수 있는가?
- 페이지 추가할 때 이와같은 구조를 사용해도 무방한가? (개인적으로 혹은 구조적으로)
- route를 관리할 수 있는 다른 좋은 방안이 있다면 추천