### PR TITLE
RH-6 : 회고 시작 전 셋팅 페이지 작업

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,10 +19,13 @@
         "react-dom": "^18.3.1",
         "react-router-dom": "^6.26.1",
         "react-scripts": "5.0.1",
+        "react-slick": "^0.30.2",
+        "slick-carousel": "^1.8.1",
         "typescript": "^4.9.5",
         "web-vitals": "^2.1.4"
       },
       "devDependencies": {
+        "@types/react-slick": "^0.23.13",
         "@typescript-eslint/eslint-plugin": "^8.0.1",
         "@typescript-eslint/parser": "^8.0.1",
         "eslint": "^8.57.0",
@@ -4186,6 +4189,15 @@
         "@types/react": "*"
       }
     },
+    "node_modules/@types/react-slick": {
+      "version": "0.23.13",
+      "resolved": "https://registry.npmjs.org/@types/react-slick/-/react-slick-0.23.13.tgz",
+      "integrity": "sha512-bNZfDhe/L8t5OQzIyhrRhBr/61pfBcWaYJoq6UDqFtv5LMwfg4NsVDD2J8N01JqdAdxLjOt66OZEp6PX+dGs/A==",
+      "dev": true,
+      "dependencies": {
+        "@types/react": "*"
+      }
+    },
     "node_modules/@types/resolve": {
       "version": "1.17.1",
       "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.17.1.tgz",
@@ -6173,6 +6185,11 @@
       "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.3.1.tgz",
       "integrity": "sha512-a3KdPAANPbNE4ZUv9h6LckSl9zLsYOP4MBmhIPkRaeyybt+r4UghLvq+xw/YwUcC1gqylCkL4rdVs3Lwupjm4Q=="
     },
+    "node_modules/classnames": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
+      "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow=="
+    },
     "node_modules/clean-css": {
       "version": "5.3.3",
       "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-5.3.3.tgz",
@@ -7310,6 +7327,11 @@
       "engines": {
         "node": ">=10.13.0"
       }
+    },
+    "node_modules/enquire.js": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/enquire.js/-/enquire.js-2.1.6.tgz",
+      "integrity": "sha512-/KujNpO+PT63F7Hlpu4h3pE3TokKRHN26JYmQpPyjkRD/N57R7bPDNojMXdi7uveAKjYB7yQnartCxZnFWr0Xw=="
     },
     "node_modules/entities": {
       "version": "2.2.0",
@@ -12290,6 +12312,12 @@
         "jiti": "bin/jiti.js"
       }
     },
+    "node_modules/jquery": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.7.1.tgz",
+      "integrity": "sha512-m4avr8yL8kmFN8psrbFFFmB/If14iN5o9nw/NgnnM+kybDJpRsAynV2BsfpTYrTRysYUdADVD7CkUUizgkpLfg==",
+      "peer": true
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -12387,6 +12415,14 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw=="
+    },
+    "node_modules/json2mq": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/json2mq/-/json2mq-0.2.0.tgz",
+      "integrity": "sha512-SzoRg7ux5DWTII9J2qkrZrqV1gt+rTaoufMxEzXbS26Uid0NwaJd123HcoB80TgubEppxxIGdNxCx50fEoEWQA==",
+      "dependencies": {
+        "string-convert": "^0.2.0"
+      }
     },
     "node_modules/json5": {
       "version": "2.2.3",
@@ -15289,6 +15325,22 @@
         }
       }
     },
+    "node_modules/react-slick": {
+      "version": "0.30.2",
+      "resolved": "https://registry.npmjs.org/react-slick/-/react-slick-0.30.2.tgz",
+      "integrity": "sha512-XvQJi7mRHuiU3b9irsqS9SGIgftIfdV5/tNcURTb5LdIokRA5kIIx3l4rlq2XYHfxcSntXapoRg/GxaVOM1yfg==",
+      "dependencies": {
+        "classnames": "^2.2.5",
+        "enquire.js": "^2.1.6",
+        "json2mq": "^0.2.0",
+        "lodash.debounce": "^4.0.8",
+        "resize-observer-polyfill": "^1.5.0"
+      },
+      "peerDependencies": {
+        "react": "^0.14.0 || ^15.0.1 || ^16.0.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^0.14.0 || ^15.0.1 || ^16.0.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/read-cache": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
@@ -15490,6 +15542,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ=="
+    },
+    "node_modules/resize-observer-polyfill": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
+      "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg=="
     },
     "node_modules/resolve": {
       "version": "1.22.8",
@@ -16148,6 +16205,14 @@
         "node": ">=8"
       }
     },
+    "node_modules/slick-carousel": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/slick-carousel/-/slick-carousel-1.8.1.tgz",
+      "integrity": "sha512-XB9Ftrf2EEKfzoQXt3Nitrt/IPbT+f1fgqBdoxO3W/+JYvtEOW6EgxnWfr9GH6nmULv7Y2tPmEX3koxThVmebA==",
+      "peerDependencies": {
+        "jquery": ">=1.8.0"
+      }
+    },
     "node_modules/sockjs": {
       "version": "0.3.24",
       "resolved": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.24.tgz",
@@ -16404,6 +16469,11 @@
       "dependencies": {
         "safe-buffer": "~5.2.0"
       }
+    },
+    "node_modules/string-convert": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/string-convert/-/string-convert-0.2.1.tgz",
+      "integrity": "sha512-u/1tdPl4yQnPBjnVrmdLo9gtuLvELKsAoRapekWggdiQNvvvum+jYF329d84NAa660KQw7pB2n36KrIKVoXa3A=="
     },
     "node_modules/string-length": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
     "react-dom": "^18.3.1",
     "react-router-dom": "^6.26.1",
     "react-scripts": "5.0.1",
+    "react-slick": "^0.30.2",
+    "slick-carousel": "^1.8.1",
     "typescript": "^4.9.5",
     "web-vitals": "^2.1.4"
   },
@@ -42,6 +44,7 @@
     ]
   },
   "devDependencies": {
+    "@types/react-slick": "^0.23.13",
     "@typescript-eslint/eslint-plugin": "^8.0.1",
     "@typescript-eslint/parser": "^8.0.1",
     "eslint": "^8.57.0",

--- a/src/components/common/TimeSelectComponent.tsx
+++ b/src/components/common/TimeSelectComponent.tsx
@@ -1,0 +1,72 @@
+import React, { useState } from 'react';
+import styles from '../../styles/common/TimeSelectComponent.module.css';
+import { TIME_TYPE } from '../../types/TimeType';
+import { DISPLAY_DEFAULT_UNIT, HOUR_TYPE, HOURS, MINUTES } from '../../constants/TimeConstant';
+
+// types
+interface CustomStyle {
+  timeSelectContainer: string | undefined,
+  timeSelectBtn: string | undefined,
+  timeSelectItems: string | undefined,
+  timeSelectItem: string | undefined,
+  timeSelectItemBtn: string | undefined,
+}
+
+interface TimeSelectComponentProps {
+  timeType: TIME_TYPE,                  // 시/분/초 중에 어떤 타입인지 정의. enum type. (필수값)
+  displayUnit: string | undefined,      // 어떤 문자를 select 요소로 보여줄 것인지 정의 (opt)
+  initDisplayText: string | undefined,  // 시간 설정 초기 문구 결정 (opt)
+  customStyle: CustomStyle | undefined, // custom font style (opt)
+}
+
+const TimeSelectComponent = (
+  { timeType, displayUnit, initDisplayText, customStyle }: TimeSelectComponentProps,
+) => {
+  const [selectedTime, setSelectedTime] = useState(initDisplayText);
+  const [isTimeSelectListOpen, setIsTimeSelectListOpen] = useState(false);
+
+  displayUnit = displayUnit !== undefined && displayUnit !== null ? displayUnit : DISPLAY_DEFAULT_UNIT.get(timeType);
+  // TODO : SECONDS 도 추가해야 함. 현재 사용하지 않아서 일단 제외
+  const displayTimeSelectItems = timeType === HOUR_TYPE ? HOURS : MINUTES;
+
+  // 클릭 시 시간 선택 리스트 노출/미노출 결정
+  const handleDisplayTimeSelectList = () => {
+    setIsTimeSelectListOpen(!isTimeSelectListOpen);
+  };
+  // 클릭 시 선택한 시간(시/분/초)를 셋팅 후 시간 선택 리스트 미노출 처리
+  const handleSelectedTimeValue = (event: React.MouseEvent<HTMLButtonElement>) => {
+    const selectedValue = event.currentTarget.innerText;
+    setSelectedTime(selectedValue);
+    setIsTimeSelectListOpen(false);
+  };
+
+  return (
+    <section className={`${styles.timeSelectContainer} ${customStyle?.timeSelectContainer}`}>
+      <button
+        className={`${styles.timeSelectBtn} ${customStyle?.timeSelectBtn}`}
+        onClick={handleDisplayTimeSelectList}
+      >
+        {selectedTime}
+      </button>
+
+      {/* timeSelectBtn을 클릭하면 isTimeSelectListOpen 값에 따라 아래 리스트가 노출/블럭 되도록 설정. */}
+      <ul
+        className={`${styles.timeSelectItems} ${isTimeSelectListOpen ? styles.displayBlock : styles.displayNone} ${customStyle?.timeSelectItems}`}>
+        {/* eslint-disable-next-line @typescript-eslint/no-unused-vars */}
+        {displayTimeSelectItems.map((timeItem, _) => (
+          <li className={`${styles.timeSelectItem} ${customStyle?.timeSelectItem}`}>
+            <button
+              className={`${styles.timeSelectItemBtn} ${customStyle?.timeSelectItemBtn}`}
+              type="button"
+              onClick={handleSelectedTimeValue}
+            >
+              {timeItem} {displayUnit}
+            </button>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+};
+
+export default TimeSelectComponent;

--- a/src/components/main/MainSection.tsx
+++ b/src/components/main/MainSection.tsx
@@ -1,7 +1,14 @@
 import React from 'react';
 import styles from './MainSection.module.css';
+import { useNavigate } from 'react-router-dom';
 
 const MainSection: React.FC = () => {
+  const navigate = useNavigate();
+
+  const startBtnClick = () => {
+    navigate('/retrospect-settings');
+  };
+
   return (
     <section className={styles.mainSection}>
       <div className={styles.leftMainSection}>
@@ -10,7 +17,7 @@ const MainSection: React.FC = () => {
           <h2 className={styles.subtitle}>당신이 원하는 회고 서비스</h2>
         </div>
         <div className={styles.startBtnWrapper}>
-          <button className={styles.startBtn}>시작하기</button>
+          <button onClick={startBtnClick} className={styles.startBtn}>시작하기</button>
         </div>
       </div>
 

--- a/src/components/retrospect-settings/GoalSetting.tsx
+++ b/src/components/retrospect-settings/GoalSetting.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import styles from '../../styles/retrospectSettings/GoalSetting.module.css';
+
+const GoalSetting: React.FC = () => {
+  return (
+    <section className={styles.rootContainer}>
+      <div>
+        <div>
+          <h1 className={styles.title}>회고 목표를 설정해볼까요?</h1>
+          <h2 className={styles.subtitle}>목표에 따라 템플릿을 추천해 드려요!</h2>
+        </div>
+
+        <div className={styles.inputContainer}>
+          <input className={`${styles.inputComponent} ${styles.inputMargin}`} placeholder={'주제'} /><br />
+          <input className={`${styles.inputComponent} ${styles.inputMargin}`} placeholder={'상세 목표'} />
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default GoalSetting;

--- a/src/components/retrospect-settings/SettingPrevNextButton.tsx
+++ b/src/components/retrospect-settings/SettingPrevNextButton.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import styles from '../../styles/retrospectSettings/SettingPrevNextButton.module.css';
+
+const FIRST_SLIDE_IDX: number = 1;
+const LAST_SLIDE_IDX: number = 3;
+
+interface SlideProps {
+  prevFn: () => void,
+  nextFn: () => void,
+  slideIdx: number,
+}
+
+const SettingPrevNextButton = ({ prevFn, nextFn, slideIdx }: SlideProps) => {
+  const isFadeOutBtn = (targetIdx: number) => {
+    return slideIdx === targetIdx ? styles.fadeOutBtn : styles.fadeInBtn;
+  };
+
+  return (
+    <section className={styles.rootContainer}>
+      <button className={`${styles.prevBtn} ${isFadeOutBtn(FIRST_SLIDE_IDX)}`} onClick={prevFn}>
+        이전
+      </button>
+
+      <button className={`${styles.nextBtn} ${isFadeOutBtn(LAST_SLIDE_IDX)}`} onClick={nextFn}>
+        다음
+      </button>
+    </section>
+  );
+};
+
+export default SettingPrevNextButton;

--- a/src/components/retrospect-settings/SlideStatusBar.tsx
+++ b/src/components/retrospect-settings/SlideStatusBar.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import styles from '../../styles/retrospectSettings/SlideStatusBar.module.css';
+
+// const FIRST_SLIDE_IDX: number = 1;
+const LAST_SLIDE_IDX: number = 3;
+const PROGRESS_BAR_WIDTH = new Map([
+  [1, '33%'],
+  [2, '66%'],
+  [3, '100%'],
+]);
+
+interface SlideProps {
+  slideIdx: number,
+}
+
+const SlideStatusBar = ({ slideIdx }: SlideProps) => {
+  console.log(slideIdx);
+
+  return (
+    <section className={styles.rootContainer}>
+      <div className={styles.progressBarWrapper}>
+        <div className={styles.progressBar}
+             style={{ width: `${PROGRESS_BAR_WIDTH.get(slideIdx)}` }}
+        ></div>
+      </div>
+
+      <span className={styles.progressText}>
+        {`${slideIdx}/${LAST_SLIDE_IDX}`}
+      </span>
+    </section>
+  );
+};
+
+export default SlideStatusBar;

--- a/src/components/retrospect-settings/TemplateSelectSetting.tsx
+++ b/src/components/retrospect-settings/TemplateSelectSetting.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import styles from '../../styles/retrospectSettings/TemplateSelectSetting.module.css';
+
+const TemplateSelectSetting: React.FC = () => {
+  return (
+    <section className={styles.rootContainer}>
+      <div>
+        <div>
+          <h1 className={styles.title}>회고 템플릿을 선택해주세요!</h1>
+          <h2 className={styles.subtitle}>자세한 설명 보기를 클릭하면 템플릿 선택에 도움이 돼요.</h2>
+        </div>
+
+        <div className={styles.templateContainer}>
+          <div className={styles.template}>
+            <span lang={"en"} className={styles.templateTitle}>KPT</span>
+            <span className={styles.templateDescription}>한 줄 설명 뭐시기</span>
+          </div>
+          <div className={styles.template}>
+            <span lang={"en"} className={styles.templateTitle}>KPT</span>
+            <span className={styles.templateDescription}>한 줄 설명 뭐시기</span>
+          </div>
+          <div className={styles.template}>
+            <span lang={"en"} className={styles.templateTitle}>KPT</span>
+            <span className={styles.templateDescription}>한 줄 설명 뭐시기</span>
+          </div>
+          <div className={styles.template}>
+            <span lang={"en"} className={styles.templateTitle}>KPT</span>
+            <span className={styles.templateDescription}>한 줄 설명 뭐시기</span>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default TemplateSelectSetting;

--- a/src/components/retrospect-settings/TimeSetting.tsx
+++ b/src/components/retrospect-settings/TimeSetting.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import styles from '../../styles/retrospectSettings/TimeSetting.module.css';
+import customTimeSelectStyles from '../../styles/retrospectSettings/CustomTimeSelect.module.css';
+import TimeSelectComponent from '../common/TimeSelectComponent';
+import { HOUR_TYPE, MINUTE_TYPE } from '../../constants/TimeConstant';
+
+interface RetrospectProps {
+  name: string,
+  avgDurationMinutes: number
+}
+
+const TimeSetting = ({ name, avgDurationMinutes }: RetrospectProps) => {
+
+  return (
+    <section className={styles.rootContainer}>
+      <div>
+        <h1 className={styles.title}>회고 진행 시간을 설정해주세요!</h1>
+        <h2 className={styles.subtitle}>
+          {`${name} 회고는 평균 ${avgDurationMinutes}분 만큼의 시간을 소요해요.`}
+        </h2>
+      </div>
+
+      <div className={styles.timeSettingContainer}>
+        <TimeSelectComponent
+          timeType={HOUR_TYPE}
+          displayUnit={''}
+          initDisplayText={"선택"}
+          customStyle={{
+            timeSelectContainer: customTimeSelectStyles.hourTimeSelectContainer,
+            timeSelectBtn: customTimeSelectStyles.hourTimeSelectBtn,
+            timeSelectItems: customTimeSelectStyles.hourTimeSelectItems,
+            timeSelectItem: customTimeSelectStyles.hourTimeSelectItem,
+            timeSelectItemBtn: customTimeSelectStyles.hourTimeSelectItemBtn,
+          }}
+        />
+        <span className={styles.hourText}>시간</span>
+        <TimeSelectComponent
+          timeType={MINUTE_TYPE}
+          displayUnit={''}
+          initDisplayText={"선택"}
+          customStyle={{
+            timeSelectContainer: customTimeSelectStyles.hourTimeSelectContainer,
+            timeSelectBtn: customTimeSelectStyles.hourTimeSelectBtn,
+            timeSelectItems: customTimeSelectStyles.hourTimeSelectItems,
+            timeSelectItem: customTimeSelectStyles.hourTimeSelectItem,
+            timeSelectItemBtn: customTimeSelectStyles.hourTimeSelectItemBtn,
+          }}
+        />
+        <span className={styles.minuteText}>분</span>
+      </div>
+    </section>
+  );
+};
+
+export default TimeSetting;

--- a/src/constants/TimeConstant.ts
+++ b/src/constants/TimeConstant.ts
@@ -1,0 +1,25 @@
+/**
+ * TimeSelectComponent.tsx 와 같이 사용될 수 있는 상수 선언
+ *
+ * @author kimjaejun
+ * @see TimeSelectComponent.tsx
+ */
+
+import { TIME_TYPE } from '../types/TimeType';
+
+// constant
+export const HOUR_TYPE: TIME_TYPE = 'hour';
+export const MINUTE_TYPE: TIME_TYPE = 'min';
+export const SECOND_TYPE: TIME_TYPE = 'second';
+
+// component config constant
+export const ZERO_PADDING: string = '0';
+export const HOURS: Array<string> = Array.from({ length: 24 }, (_, hour) => {
+  return String(hour).padStart(2, ZERO_PADDING);
+});
+export const MINUTES: Array<string> = Array.from({ length: 60 }, (_, minute) => {
+  return String(minute).padStart(2, ZERO_PADDING);
+});
+export const DISPLAY_DEFAULT_UNIT = new Map([
+  [HOUR_TYPE, '시간'], [MINUTE_TYPE, '분'], [SECOND_TYPE, '초'], ['', '']
+]);

--- a/src/index.css
+++ b/src/index.css
@@ -33,6 +33,6 @@ body {
   font-family: var(--ko-font), sans-serif;
 }
 
-body:lang(en), div:lang(en), p:lang(en), h1:lang(en), h2:lang(en), h3:lang(en), h4:lang(en), h5:lang(en), h6:lang(en) {
+body:lang(en), span:lang(en), div:lang(en), p:lang(en), h1:lang(en), h2:lang(en), h3:lang(en), h4:lang(en), h5:lang(en), h6:lang(en) {
   font-family: var(--en-font), sans-serif;
 }

--- a/src/pages/retrospect-setting/page.tsx
+++ b/src/pages/retrospect-setting/page.tsx
@@ -2,10 +2,11 @@ import React, { useState } from 'react';
 import Slider from 'react-slick';
 import 'slick-carousel/slick/slick.css';
 import 'slick-carousel/slick/slick-theme.css';
-import FirstSetting from '../../components/retrospect-settings/FirstSetting';
-import SecondSetting from '../../components/retrospect-settings/SecondSetting';
+import GoalSetting from '../../components/retrospect-settings/GoalSetting';
+import TemplateSelectSetting from '../../components/retrospect-settings/TemplateSelectSetting';
 import SettingPrevNextButton from '../../components/retrospect-settings/SettingPrevNextButton';
 import SlideStatusBar from '../../components/retrospect-settings/SlideStatusBar';
+import TimeSetting from '../../components/retrospect-settings/TimeSetting';
 
 const RetrospectSettingsPage = () => {
   const [slideIdx, setSlideIdx] = useState<number>(1);
@@ -37,11 +38,13 @@ const RetrospectSettingsPage = () => {
   };
   return (
     <section>
-      <SlideStatusBar slideIdx={slideIdx}/>
+      <SlideStatusBar slideIdx={slideIdx} />
 
       <Slider ref={sliderRef} {...sliderSettings}>
-        <FirstSetting />
-        <SecondSetting />
+        <GoalSetting />
+        <TemplateSelectSetting />
+        {/* TODO : name, time은 API를 통해 받아와야 함 */}
+        <TimeSetting name={'KPT'} avgDurationMinutes={120} />
       </Slider>
 
       <SettingPrevNextButton

--- a/src/pages/retrospect-setting/page.tsx
+++ b/src/pages/retrospect-setting/page.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+const RetrospectSettingsPage = () => {
+  return (
+    <h1>Here is RetrospectSettingsPage</h1>
+  );
+};
+
+export default RetrospectSettingsPage;

--- a/src/pages/retrospect-setting/page.tsx
+++ b/src/pages/retrospect-setting/page.tsx
@@ -1,42 +1,54 @@
-import React from 'react';
-// import Slider from 'react-slick';
-// import 'slick-carousel/slick/slick.css';
-// import 'slick-carousel/slick/slick-theme.css';
+import React, { useState } from 'react';
+import Slider from 'react-slick';
+import 'slick-carousel/slick/slick.css';
+import 'slick-carousel/slick/slick-theme.css';
 import FirstSetting from '../../components/retrospect-settings/FirstSetting';
-// import { baseUrl } from "./config";
+import SecondSetting from '../../components/retrospect-settings/SecondSetting';
+import SettingPrevNextButton from '../../components/retrospect-settings/SettingPrevNextButton';
 
 const RetrospectSettingsPage = () => {
-  // const settings = {
-  //   dots: true,
-  //   infinite: true,
-  //   speed: 500,
-  //   slidesToShow: 1,
-  //   slidesToScroll: 1,
-  // };
+  const [slideIdx, setSlideIdx] = useState<number>(1);
+  const handleSlideIdx = (newSlideIdx: number) => {
+    if (newSlideIdx < 1) {
+      newSlideIdx = 1;
+    } else if (newSlideIdx > 3) {
+      newSlideIdx = 3;
+    }
+    setSlideIdx(newSlideIdx);
+  };
+
+  const sliderRef = React.createRef<Slider>();
+  const next: () => void = () => {
+    sliderRef.current?.slickNext();
+    handleSlideIdx(slideIdx + 1);
+  };
+  const previous: () => void = () => {
+    sliderRef.current?.slickPrev();
+    handleSlideIdx(slideIdx - 1);
+  };
+
+  const sliderSettings = {
+    arrows: false,
+    infinite: false,
+    speed: 500,
+    slidesToShow: 1,
+    slidesToScroll: 1,
+  };
   return (
     <section>
+      {/* TODO : 컴포넌트 구현 필요 */}
       {/* <StatusBar /> */}
-      <FirstSetting />
-      {/* <progressBtnSection /> */}
 
+      <Slider ref={sliderRef} {...sliderSettings}>
+        <FirstSetting />
+        <SecondSetting />
+      </Slider>
 
-      {/*<Slider {...settings}>*/}
-      {/*  <div>*/}
-      {/*    <h3 style={{ color: '#FFFAFF', backgroundColor: '#ABD1A9' }}>1</h3>*/}
-      {/*  </div>*/}
-      {/*  <div>*/}
-      {/*    <h3 style={{ color: '#FFFAFF', backgroundColor: '#ffba13' }}>2</h3>*/}
-      {/*  </div>*/}
-      {/*  <div>*/}
-      {/*    <h3 style={{ color: '#FFFAFF', backgroundColor: '#00fff7' }}>3</h3>*/}
-      {/*  </div>*/}
-      {/*  <div>*/}
-      {/*    <h3 style={{ color: '#FFFAFF', backgroundColor: '#ff2141' }}>4</h3>*/}
-      {/*  </div>*/}
-      {/*  <div>*/}
-      {/*    <h3 style={{ color: '#FFFAFF', backgroundColor: '#4a3eff' }}>5</h3>*/}
-      {/*  </div>*/}
-      {/*</Slider>*/}
+      <SettingPrevNextButton
+        prevFn={previous}
+        nextFn={next}
+        slideIdx={slideIdx}
+      />
     </section>
   );
 };

--- a/src/pages/retrospect-setting/page.tsx
+++ b/src/pages/retrospect-setting/page.tsx
@@ -1,8 +1,43 @@
 import React from 'react';
+// import Slider from 'react-slick';
+// import 'slick-carousel/slick/slick.css';
+// import 'slick-carousel/slick/slick-theme.css';
+import FirstSetting from '../../components/retrospect-settings/FirstSetting';
+// import { baseUrl } from "./config";
 
 const RetrospectSettingsPage = () => {
+  // const settings = {
+  //   dots: true,
+  //   infinite: true,
+  //   speed: 500,
+  //   slidesToShow: 1,
+  //   slidesToScroll: 1,
+  // };
   return (
-    <h1>Here is RetrospectSettingsPage</h1>
+    <section>
+      {/* <StatusBar /> */}
+      <FirstSetting />
+      {/* <progressBtnSection /> */}
+
+
+      {/*<Slider {...settings}>*/}
+      {/*  <div>*/}
+      {/*    <h3 style={{ color: '#FFFAFF', backgroundColor: '#ABD1A9' }}>1</h3>*/}
+      {/*  </div>*/}
+      {/*  <div>*/}
+      {/*    <h3 style={{ color: '#FFFAFF', backgroundColor: '#ffba13' }}>2</h3>*/}
+      {/*  </div>*/}
+      {/*  <div>*/}
+      {/*    <h3 style={{ color: '#FFFAFF', backgroundColor: '#00fff7' }}>3</h3>*/}
+      {/*  </div>*/}
+      {/*  <div>*/}
+      {/*    <h3 style={{ color: '#FFFAFF', backgroundColor: '#ff2141' }}>4</h3>*/}
+      {/*  </div>*/}
+      {/*  <div>*/}
+      {/*    <h3 style={{ color: '#FFFAFF', backgroundColor: '#4a3eff' }}>5</h3>*/}
+      {/*  </div>*/}
+      {/*</Slider>*/}
+    </section>
   );
 };
 

--- a/src/pages/retrospect-setting/page.tsx
+++ b/src/pages/retrospect-setting/page.tsx
@@ -5,6 +5,7 @@ import 'slick-carousel/slick/slick-theme.css';
 import FirstSetting from '../../components/retrospect-settings/FirstSetting';
 import SecondSetting from '../../components/retrospect-settings/SecondSetting';
 import SettingPrevNextButton from '../../components/retrospect-settings/SettingPrevNextButton';
+import SlideStatusBar from '../../components/retrospect-settings/SlideStatusBar';
 
 const RetrospectSettingsPage = () => {
   const [slideIdx, setSlideIdx] = useState<number>(1);
@@ -36,8 +37,7 @@ const RetrospectSettingsPage = () => {
   };
   return (
     <section>
-      {/* TODO : 컴포넌트 구현 필요 */}
-      {/* <StatusBar /> */}
+      <SlideStatusBar slideIdx={slideIdx}/>
 
       <Slider ref={sliderRef} {...sliderSettings}>
         <FirstSetting />

--- a/src/routes/RetrospectSettingsRoutes.tsx
+++ b/src/routes/RetrospectSettingsRoutes.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { RouteObject } from 'react-router-dom';
+import RetrospectSettingsPage from '../pages/retrospect-setting/page';
+
+const retrospectSettingsRoutes: RouteObject[] = [
+  {
+    path: '/retrospect-settings',
+    element: <RetrospectSettingsPage />,
+  },
+];
+
+export default retrospectSettingsRoutes;

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -4,6 +4,7 @@ import mainServiceRoutes from './MainServiceRoutes';
 import reHubTemplateRoutes from './ReHubTemplatesRoutes';
 import ourStoryRoutes from './OurStoryRoutes';
 import customerSupportRoutes from './CustomerSupportRoutes';
+import retrospectSettingsRoutes from './RetrospectSettingsRoutes';
 
 const routes: RouteObject[] = [
   ...homeRoutes,
@@ -11,6 +12,7 @@ const routes: RouteObject[] = [
   ...reHubTemplateRoutes,
   ...ourStoryRoutes,
   ...customerSupportRoutes,
+  ...retrospectSettingsRoutes
 ];
 
 export default routes;

--- a/src/styles/common/TimeSelectComponent.module.css
+++ b/src/styles/common/TimeSelectComponent.module.css
@@ -1,0 +1,78 @@
+/* 시/분/초 를 고를 수 있는 요소의 최외곽 부모요소 */
+.timeSelectContainer {
+  position: relative;
+  width: 200px;
+}
+
+.timeSelectBtn {
+  width: 100%;
+  padding: 13px 30px 13px 14px;
+  font-size: 12px;
+  line-height: 14px;
+  background-color: #fff;
+  border: 1px solid #C4C4C4;
+  box-sizing: border-box;
+  border-radius: 10px;
+  cursor: pointer;
+  text-align: left;
+  /* 말줄임 */
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  overflow: hidden;
+}
+
+.timeSelectBtn:hover, .timeSelectBtn:focus {
+  border: 1px solid #9B51E0;
+  outline: 3px solid #F8E4FF;
+}
+
+.timeSelectItems {
+  list-style-type: none;
+  display: none;
+  position: absolute;
+  width: 100%;
+  top: 35px;
+  left: 0;
+  padding: 0;
+  border: 1px solid #C4C4C4;
+  box-sizing: border-box;
+  box-shadow: 4px 4px 14px rgba(0, 0, 0, 0.15);
+  border-radius: 10px;
+  /* scroll setting */
+  height: 300px;
+  overflow: auto;
+}
+
+.displayBlock {
+  display: block;
+}
+
+.displayNone {
+  display: none;
+}
+
+.timeSelectItem {
+  width: 100%;
+  height: 40px;
+  padding: 5px 8px;
+  box-sizing: border-box;
+}
+
+.timeSelectItemBtn {
+  width: 100%;
+  padding: 7px 10px;
+  border: none;
+  background-color: #fff;
+  border-radius: 8px;
+  cursor: pointer;
+  text-align: left;
+  /* 말줄임 */
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  overflow: hidden;
+}
+
+.timeSelectItemBtn:hover,
+.timeSelectItemBtn:focus {
+  background-color: #F8E4FF;
+}

--- a/src/styles/retrospectSettings/CustomTimeSelect.module.css
+++ b/src/styles/retrospectSettings/CustomTimeSelect.module.css
@@ -1,0 +1,95 @@
+/*
+TimeSelectComponent 의 스타일을 커스텀하게 적용하기 위한 CSS
+
+사용법
+- 기존 컴포넌트의 스타일을 override 하는 방식으로 구현
+  - 따라서 !important 필수
+- 기존 컴포넌트와 다른 부분은 'custom' 이라는 주석 하위에 스타일 선언
+  - 그리고 기존 컴포넌트의 코드는 삭제가 아닌 주석처리 (수정부분 용이하게 확인하기 위함)
+*/
+
+.hourTimeSelectContainer {
+  position: relative !important;
+  /*width: 100px !important;*/
+
+  /* custom */
+  width: 120px !important;
+}
+
+.hourTimeSelectBtn {
+  width: 100% !important;
+  /*padding: 13px 30px 13px 14px !important;*/
+  /*font-size: 12px !important;*/
+  /*line-height: 14px !important;*/
+  background-color: #fff !important;
+  border: 1px solid #C4C4C4 !important;
+  box-sizing: border-box !important;
+  border-radius: 10px !important;
+  cursor: pointer !important;
+  /* 말줄임 */
+  white-space: nowrap !important;
+  text-overflow: ellipsis !important;
+  overflow: hidden !important;
+
+  /* custom */
+  padding: 13px 20px 13px 14px !important; /* 텍스트 중앙정렬을 위해서 필수 */
+  font-size: 24px !important;
+  line-height: 26px !important;
+  text-align: center !important;
+  /*height: 80px !important;*/ /* 향후 높이 설정하고 싶을 때 사용. 그러나 높이를 올리면 hourTimeSelectItems의 top값도 올려줘야 함 */
+}
+
+.hourTimeSelectBtn:hover, .hourTimeSelectBtn:focus {
+  border: 1px solid #9B51E0 !important;
+  outline: 3px solid #F8E4FF !important;
+}
+
+.hourTimeSelectItems {
+  list-style-type: none !important;
+  /*display: none !important; <-- 제거해야 리스트 노출/미노출 동작함 */
+  position: absolute !important;
+  width: 100% !important;
+  /*top: 35px !important;*/
+  left: 0 !important;
+  padding: 0 !important;
+  border: 1px solid #C4C4C4 !important;
+  box-sizing: border-box !important;
+  box-shadow: 4px 4px 14px rgba(0, 0, 0, 0.15) !important;
+  border-radius: 10px !important;
+  /* scroll setting */
+  height: 300px !important;
+  overflow: auto !important;
+
+  /* custom */
+  top: 40px !important; /* 선택 버튼과 리스트의 간격 */
+}
+
+.hourTimeSelectItem {
+  width: 100% !important;
+  height: 60px !important;
+  padding: 5px 8px !important;
+  box-sizing: border-box !important;
+}
+
+.hourTimeSelectItemBtn {
+  width: 100% !important;
+  padding: 7px 10px !important;
+  border: none !important;
+  background-color: #fff !important;
+  border-radius: 8px !important;
+  cursor: pointer !important;
+  /*text-align: left !important;*/
+  /* 말줄임 */
+  white-space: nowrap !important;
+  text-overflow: ellipsis !important;
+  overflow: hidden !important;
+
+  /* custom */
+  font-size: 22px;
+  text-align: center !important;
+}
+
+.hourTimeSelectItemBtn:hover,
+.hourTimeSelectItemBtn:focus {
+  background-color: #F8E4FF !important;
+}

--- a/src/styles/retrospectSettings/GoalSetting.module.css
+++ b/src/styles/retrospectSettings/GoalSetting.module.css
@@ -1,0 +1,47 @@
+.rootContainer {
+  /* 현재 section container 화면 정중앙 위치 */
+  display: flex;
+  flex-direction: column;
+  align-items: center; /* 수평 중앙 정렬 */
+  justify-content: center; /* 수직 중앙 정렬 */
+  height: 100vh; /* 브라우저의 높이만큼 .container 의 영역 */
+}
+
+.title {
+  font-size: 3vw;
+  margin: 0;
+}
+
+.subtitle {
+  font-size: 1.5vw;
+  margin-top: 20px;
+  margin-bottom: 20px;
+}
+
+.inputContainer {
+  margin-top: 40px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  /*background-color: #434343;*/
+}
+
+/*
+여기서부터는 input만을 위한 것.
+컴포넌트화 필요
+*/
+.inputComponent {
+  width: 100%;
+  height: 8vh;
+  border-radius: 12px;
+  border: #c4c4c4 solid 2px;
+
+  font-size: 1.5vw;
+  text-align: center;
+  font-weight: bold;
+}
+
+.inputMargin {
+  margin-top: 10px;
+  margin-bottom: 10px;
+}

--- a/src/styles/retrospectSettings/SettingPrevNextButton.module.css
+++ b/src/styles/retrospectSettings/SettingPrevNextButton.module.css
@@ -1,0 +1,60 @@
+.rootContainer {
+  /*display: flex;*/
+  /*flex-direction: row;*/
+  /*align-items: center;*/
+  /*justify-content: space-around;*/
+
+  /*position: fixed;*/
+  /*bottom: 80px;*/
+  /*width: 100%;*/
+  /*height: 10vh;*/
+  /*text-align: center;*/
+}
+
+.prevBtn {
+  position: fixed;
+  left: 380px;
+  bottom: 80px;
+
+  padding: 0.8vw 2vw;
+  font-size: 1.8vw;
+  border-radius: 8px;
+  border: none;
+  background: none;
+  color: var(--normal-color);
+}
+
+.nextBtn {
+  position: fixed;
+  right: 380px;
+  bottom: 80px;
+
+  padding: 0.8vw 2vw;
+  font-size: 1.8vw;
+
+  border: white solid 2px;
+  border-radius: 8px;
+  background-color: var(--primary-color);
+  color: whitesmoke;
+}
+
+.fadeInBtn {
+  transition: opacity 0.3s ease-out, visibility 0.5s ease-out;
+  opacity: 1;
+  visibility: visible;
+}
+
+.fadeOutBtn {
+  transition: opacity 0.3s ease-out, visibility 0.5s ease-out;
+  opacity: 0;
+  visibility: hidden;
+}
+
+.nextBtn:hover {
+  background-color: var(--secondary-color);
+}
+
+.prevBtn:hover, .nextBtn:hover {
+  cursor: pointer;
+  font-weight: bold;
+}

--- a/src/styles/retrospectSettings/SlideStatusBar.module.css
+++ b/src/styles/retrospectSettings/SlideStatusBar.module.css
@@ -1,0 +1,28 @@
+.rootContainer {
+  position: fixed;
+  top: 18vh;
+  left: 0;
+  height: 12px;
+  width: 100%;
+
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.progressBarWrapper {
+  width: 36vw;
+}
+
+.progressBar {
+  border-radius: 12px;
+  height: 12px;
+  width: 0;
+  background-color: var(--primary-color);
+  transition: width 0.3s ease;
+}
+
+.progressText {
+  padding-left: 12px;
+  font-size: 18px;
+}

--- a/src/styles/retrospectSettings/TemplateSelectSetting.module.css
+++ b/src/styles/retrospectSettings/TemplateSelectSetting.module.css
@@ -1,0 +1,56 @@
+.rootContainer {
+  /* 현재 section container 화면 정중앙 위치 */
+  display: flex;
+  flex-direction: column;
+  align-items: center; /* 수평 중앙 정렬 */
+  justify-content: center; /* 수직 중앙 정렬 */
+  height: 100vh; /* 브라우저의 높이만큼 .container 의 영역 */
+}
+
+.title {
+  font-size: 3vw;
+  margin: 0;
+}
+
+.subtitle {
+  font-size: 1.2vw;
+  margin-top: 20px;
+  margin-bottom: 20px;
+}
+
+/* TODO : TemplateSelectComponent 로 분리 필요 */
+.templateContainer {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  row-gap: 20px;
+  place-items: center; /* grid item center */
+}
+
+.template {
+  width: 280px;
+  height: 180px;
+  padding: 20px;
+  text-align: center;
+  border-radius: 12px;
+  border: #c4c4c4 solid 2px;
+
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  row-gap: 10px;
+}
+
+.template:hover {
+  border: var(--primary-color) solid 4px;
+  cursor: pointer;
+  font-weight: bolder;
+}
+
+.templateTitle {
+  font-size: 1.7vw;
+  font-weight: bold;
+}
+
+.templateDescription {
+  font-size: 1.1vw;
+}

--- a/src/styles/retrospectSettings/TimeSetting.module.css
+++ b/src/styles/retrospectSettings/TimeSetting.module.css
@@ -1,0 +1,33 @@
+.rootContainer {
+  /* 현재 section container 화면 정중앙 위치 */
+  display: flex;
+  flex-direction: column;
+  align-items: center; /* 수평 중앙 정렬 */
+  justify-content: center; /* 수직 중앙 정렬 */
+  height: 100vh; /* 브라우저의 높이만큼 .container 의 영역 */
+}
+
+.title {
+  font-size: 3vw;
+  margin: 0;
+}
+
+.subtitle {
+  font-size: 1.5vw;
+  margin-top: 20px;
+  margin-bottom: 20px;
+}
+
+.timeSettingContainer {
+  margin-top: 40px;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: center;
+  column-gap: 20px;
+}
+
+.hourText, .minuteText {
+  font-size: 30px;
+  font-weight: bold;
+}

--- a/src/types/TimeType.ts
+++ b/src/types/TimeType.ts
@@ -1,0 +1,7 @@
+const TIME_TYPE = {
+  HOUR: 'hour',
+  MINUTE: 'min',
+  SECOND: 'second'
+} as const;
+
+export type TIME_TYPE = typeof TIME_TYPE[keyof typeof TIME_TYPE];


### PR DESCRIPTION
jira : https://choorai.atlassian.net/browse/RH-6
참고한 링크들은 모두 티켓에 남겨놨습니다.

# 내용
## 개발 방식
- CSS 파일을 `styles` 하위 디렉토리에서 선언하면 좋을 것 같다는 피드백을 회사 동료로부터 받아서... 현재 PR부터는 그렇게 하도록 했습니다.
  - [가이드 위키](https://github.com/choorai/retrospect-frontend/wiki/Front%E2%80%90end-develop-%EA%B0%80%EC%9D%B4%EB%93%9C) 수정 완료

## 의존성 관련
### react-slick 의존성 추가
- `react-slick` slide 패키지 추가

회고 설정 화면을 슬라이드 형식으로 보여주기 위해서, 슬라이드 라이브러리 사용. ([React-slick](https://react-slick.neostack.com/docs/example/slick-go-to))

## 페이지 컴포넌트
### 슬라이드1 : 회고 주제 및 상세내용
- 현재는 `input`을 공통 컴포넌트로 분리하지 않았음. 향후 분리 필요

### 슬라이드2 : 회고 템플릿 선택
- template card 컴포넌트 개발필요. 현재는 진행하지 않음. (어차피 KPT 1개일거라서 하드코딩 해놔도 무방하다고 생각)

### 슬라이드3 : 회고 시간 설정
- `TimeSelectComponent`공통 컴포넌트를 선개발 후, 회고 시간 설정 페이지에 적용
- enum을 사용하는 것 보다 더 좋은 방법이 있다고 하여 [해당링크](https://engineering.linecorp.com/ko/blog/typescript-enum-tree-shaking)를 참고하여 `TIME_TYPE` enum을 선언해서 사용했습니다.
  - TS 쓰는 겸사겸사 string으로 시간타입을 넘기는게 아닌, enum 타입으로 엄격히 코드를 관리하기 위함.

### 이전/다음 선택 버튼
- react-slick 사용해서 이전/다음 슬라이드로 이동할 수 있는 버튼 컴포넌트 개발

### 슬라이드 progress bar
- useState 사용하여 현재 슬라이드 index를 확인해서 progress bar UI 변경하도록 개발

## 공통 컴포넌트
### 시간 Select Box - `TimeSelectComponent`
- 시간 설정 공통 컴포넌트

## 리뷰 시 참고
commit 별로 구분하여 기능을 개발했으니, 전체 코드보다는 커밋별로 확인하시면 리뷰하기가 더 수월해집니다.